### PR TITLE
Fix dependabot automation, correct repo

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'MusicalNinjaDad/FizzBuzz'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'MusicalNinjaDad/pt'
     steps:
       - name: Ensure this is a valid dependabot PR
         id: metadata


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust Dependabot merge workflow condition to use the current repository name instead of the previous one.